### PR TITLE
ci(release): publish via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
         required: true
         default: 'skip'
 
+permissions:
+  contents: write
+  id-token: write
+
 jobs:
   prepare:
     uses: metanorma/ci/.github/workflows/prepare-rake.yml@main
@@ -46,9 +50,11 @@ jobs:
           git tag v${{ inputs.next_version }}
           git push origin HEAD:${GITHUB_REF} --tags
 
+      # Exchange the job's OIDC token (id-token: write) for a short-lived RubyGems API key.
+      - uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
       - uses: actions-mn/gem-release@main
         with:
-          api-key: ${{ secrets.METANORMA_CI_RUBYGEMS_API_KEY }}
+          bearer-token: ${{ env.RUBYGEMS_API_KEY }}
           release-command: gem release
 
       - if: failure()


### PR DESCRIPTION
## Summary
- Switches gem publishing from the revoked `METANORMA_CI_RUBYGEMS_API_KEY` secret to **OIDC trusted publishing**: `rubygems/configure-rubygems-credentials` (v2.1.0, pinned) exchanges the job's OIDC token for a short-lived API key, fed to `actions-mn/gem-release` via its `bearer-token` input (the action hard-fails without a key/bearer, so it cannot fall back on its own).
- Adds `permissions: contents: write, id-token: write` — required for the token exchange (and tag pushing).
- No long-lived secret remains; the gem's trusted publisher (`<repo> @ release.yml`, inline shape) is already configured on rubygems.org.

## Test plan
- [x] YAML parses.
- [ ] After merge: dispatch release with `next_version=skip` — the current version is already published, so the push is a no-op that exercises only the OIDC exchange.
